### PR TITLE
[#154593617] allow non-teacher users

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -207,7 +207,7 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
 
-  config.cas_base_url = "https://metododerose.org:8443"
+  config.cas_base_url = "https://metododerose.org:9443"
   config.cas_username_column = "drc_uid"
 
   # ==> Warden configuration


### PR DESCRIPTION
cambié la URL del CAS server a una de la versión que permite registro de usuarios.
esto permite que las escuelas que tienen estagiarios, empleados o sêvins laburando en padma puedan tener acceso sin usar el usuario de un instructor.